### PR TITLE
Update metadata handling during initial HDF5 file creation to allow for ...

### DIFF
--- a/trunk/src/voyeur/db.py
+++ b/trunk/src/voyeur/db.py
@@ -34,36 +34,23 @@ class Persistor(object):
     
     h5file = None
 
-    def create_database(self, 
-                        filename, 
-                        animal_id,
-                        session_number,
-                        rig,
-                        user,
-                        experiment_notes,
-                        voyeur_version,
-                        usercode_version,
-                        arduino_protocol_name,
-                        user_protocol_name,
-                        start_date,
-                        timezone,
-                        user_metadata):
-        """Creates an HDF5 database and defines metadata"""    
+    def create_database(self, filename, metadata):
+        """
+        Create database file and add initial metadata attributes.
+
+        :param filename: Path to save HDF5 file.
+        :param metadata: Dict containing metadata. Metadata items will be added to root group of H5 file
+        :type filename: str
+        :type metadata: dict
+        :return: session_group
+        """
         if os.path.splitext(filename)[-1] == 'h5':
             filename = os.path.splitext(filename)[0]
         self.h5file = tables.open_file(filename + ".h5", mode = "w")
         #group_name = 'animal' + str(animal_id) + '_session' + str(animal_id)
         session_group = self.h5file.root #create_group("/", group_name, user_metadata)
-        session_group._v_attrs.animal_id = animal_id
-        session_group._v_attrs.rig = rig
-        session_group._v_attrs.user = user
-        session_group._v_attrs.experiment_notes = experiment_notes
-        session_group._v_attrs.voyeur_version = voyeur_version
-        session_group._v_attrs.usercode_version = usercode_version
-        session_group._v_attrs.arduino_protocol_name = arduino_protocol_name
-        session_group.user_protocol_name = user_protocol_name
-        session_group._v_attrs.start_date = start_date
-        session_group._v_attrs.timezone = timezone
+        for k, v in metadata.iteritems():
+            session_group._f_setattr(k, v)
         self.h5file.flush()
         
         return session_group

--- a/trunk/src/voyeur/monitor.py
+++ b/trunk/src/voyeur/monitor.py
@@ -120,35 +120,28 @@ class Monitor(HasTraits):
         except SerialException as e:
             print('Serial Port 1 Error')
             print('Serial exception. Message: ', e.msg, ' Path: ', e.path)
-        
+
         self.protocol_name = self.serial1.request_protocol_name()
-        self.start_date = self.persistor.timestamp()
-        
-        # For debugging
-        #self.start_date = self.persistor.timestamp()
+        ### Define monitor metadata. This metadata is consistent between all protocols.
+        self.metadata = {'arduino_protocol_name': self.protocol_name,
+                         'start_date': time.mktime(time.localtime()),
+                         #todo: add VOYEUR core version hash or version number lookup.
+                         }
+
+
         
         
     def _database_file_changed(self):
+        initial_metadata = dict(self.metadata.items() + self.protocol.metadata.items())  # combine protocol and monitor metadata
         if self.serial1 != None:
             #self.serial_queue1.enqueue(self.persistor.close_database)
-            self.current_session_group = self.persistor.create_database(self.database_file,
-                                                                        self.animal_id,
-                                                                        self.session_number,
-                                                                        self.rig,
-                                                                        self.user,
-                                                                        self.experiment_notes,
-                                                                        self.voyeur_version,
-                                                                        self.usercode_version,
-                                                                        self.arduino_protocol_name,
-                                                                        self.user_protocol_name,
-                                                                        self.start_date,
-                                                                        self.timezone,
-                                                                        self.user_metadata)            
+            self.current_session_group = self.persistor.create_database(self.database_file, initial_metadata)
+
             self.persistor.create_trials(self.protocol.protocol_parameters_definition(),
                                             self.protocol.controller_parameters_definition(),
                                             self.protocol.event_definition(),
                                             self.current_session_group,
-                                            '')            
+                                            '')
         
     def _protocol_changed(self, name, old, new):
         """

--- a/trunk/src/voyeur/protocol.py
+++ b/trunk/src/voyeur/protocol.py
@@ -37,6 +37,12 @@ class IProtocol(IPlugin):
 
     """
 
+    # This is a placeholder for a metadata dictionary. Items in the metadata dictionary are written as attributes to the
+    # session attributes of the HDF5 file at file creation time.
+    # FUTURE: changes to this dictionary after session start will result in attribute addition or change.
+    metadata = {}
+
+
     @abc.abstractmethod
     def protocol_parameters_definition(self):
         """
@@ -159,6 +165,8 @@ class IProtocol(IPlugin):
         """A string description of the protocol"""
 
         return self.__class__.__name__ + ' protocol'
+
+
 
 class Protocol(ui.HasTraits, IProtocol):
     pass


### PR DESCRIPTION
...protocol-defined attribute setting at run-time.

Items within a protocol.metadata dictionary are now written as attributes of the HDF5 file. Monitor provides limited, hard coded attribute setting: time of database creation and the arduino code string.
